### PR TITLE
decrease time complexity of vcf loading

### DIFF
--- a/PAINTOR_Utilities/CalcLD_1KG_VCF.py
+++ b/PAINTOR_Utilities/CalcLD_1KG_VCF.py
@@ -79,7 +79,8 @@ def Extract_Pop_Haps(vcf_rows, pop_ids):
     """Extract (continental) population haplotypes and return a numpy matrix with haplotypes"""
     header = vcf_rows[0]
     header_str = [item.decode("utf-8") for item in header]
-    extract_index = [header_str.index(ids) for ids in pop_ids]
+    pop_ids_set = set(pop_ids)
+    extract_index = [index for (index, ids) in enumerate(header_str) if ids in pop_ids_set]
     pop_haps =[]
     for rows in vcf_rows[1::]:
         hap_list = [rows[i].decode("utf-8").split("|") for i in extract_index]


### PR DESCRIPTION
Before extracting the population haplotypes to generate an LD matrix, this script parses the VCF header to find the indices of the samples that belong to a certain population.
This patch decreases the time complexity of the header parsing from O(n^2) to O(n).