### PR TITLE
check that there is at least one locus to process

### DIFF
--- a/Functions_IO.cpp
+++ b/Functions_IO.cpp
@@ -295,6 +295,10 @@ void Get_all_input(string& file_list_name, vector<Locus>& all_loci,  execution_p
         current_locus.set_annotations(locus_annotations);
         all_loci.push_back(current_locus);
     }
+    if (!all_loci.size()) {
+        cout << "No locus was loaded. Please check the inputs" << endl;
+        exit(1);
+    }
     cout << "**********" <<  endl;
 }
 


### PR DESCRIPTION
If the -input parameter is badly specified, the program ends with an unhelpful "Floating point exception", as it tries to divide something by the number of loci.
It now aborts with a more specific message when no locus is loaded.